### PR TITLE
Fix font size and wrapping on code examples

### DIFF
--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -99,28 +99,6 @@ export default {
           color: "accent",
         },
       },
-      code: {
-        fontSize: 1,
-        background: "transparent",
-        '&[class*="language-"]': {
-          fontSize: 1,
-          background: "transparent",
-        },
-        '*:not(pre) > &[class*="language-"]': {
-          whiteSpace: "pre-wrap",
-          wordBreak: "break-word",
-        },
-      },
-      pre: {
-        background: "transparent",
-        border: "1px solid",
-        borderColor: "muted",
-        marginBottom: 4,
-        '&[class*="language-"]': {
-          background: "transparent",
-          marginBottom: 4,
-        },
-      },
       ".gatsby-resp-image-image": {
         boxShadow: "none !important",
       },
@@ -145,6 +123,34 @@ export default {
           color: "secondary",
           lineHeight: "heading",
         },
+      },
+    },
+    code: {
+      background: "transparent",
+      '&[class*="language-"]': {
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-word",
+        background: "transparent",
+        fontSize: 1,
+      },
+      ':not(pre) > &[class*="language-"]': {
+        background: "transparent",
+      },
+    },
+    pre: {
+      background: "transparent",
+      border: "1px solid",
+      borderColor: "muted",
+      marginBottom: 4,
+      lineHeight: "1",
+
+      '&[class*="language-"]': {
+        background: "transparent",
+        marginBottom: 4,
+        code: {
+          whiteSpace: "pre",
+          fontSize: 0,
+        }
       },
     },
     a: {

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -128,8 +128,8 @@ export default {
     code: {
       background: "transparent",
       '&[class*="language-"]': {
-        whiteSpace: "pre-wrap",
-        wordBreak: "break-word",
+        whiteSpace: "pre",
+        wordBreak: "normal",
         background: "transparent",
         fontSize: 1,
       },

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -121,7 +121,7 @@ export default {
           code: {
             whiteSpace: "pre !important",
             fontSize: 0,
-          }
+          },
         },
       },
       ".gatsby-resp-image-image": {
@@ -172,7 +172,7 @@ export default {
         code: {
           whiteSpace: "pre !important",
           fontSize: 0,
-        }
+        },
       },
     },
     a: {

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -99,6 +99,31 @@ export default {
           color: "accent",
         },
       },
+      code: {
+        ':not(pre) > &[class*="language-"], &': {
+          background: "transparent",
+          whiteSpace: "pre-wrap",
+          wordBreak: "normal",
+          background: "transparent",
+          fontSize: 1,
+        },
+      },
+      pre: {
+        background: "transparent",
+        border: "1px solid",
+        borderColor: "muted",
+        marginBottom: 4,
+        lineHeight: "1",
+
+        '&[class*="language-"]': {
+          background: "transparent",
+          marginBottom: 4,
+          code: {
+            whiteSpace: "pre !important",
+            fontSize: 0,
+          }
+        },
+      },
       ".gatsby-resp-image-image": {
         boxShadow: "none !important",
       },
@@ -126,15 +151,12 @@ export default {
       },
     },
     code: {
-      background: "transparent",
-      '&[class*="language-"]': {
-        whiteSpace: "pre",
-        wordBreak: "normal",
-        background: "transparent",
+      ':not(pre) > &[class*="language-"], &': {
+        background: "transparent !important",
+        whiteSpace: "pre-wrap !important",
+        wordBreak: "normal !important",
+        background: "transparent !important",
         fontSize: 1,
-      },
-      ':not(pre) > &[class*="language-"]': {
-        background: "transparent",
       },
     },
     pre: {
@@ -148,9 +170,9 @@ export default {
         background: "transparent",
         marginBottom: 4,
         code: {
-          whiteSpace: "pre",
+          whiteSpace: "pre !important",
           fontSize: 0,
-        },
+        }
       },
     },
     a: {

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -196,16 +196,16 @@ export default props => {
               <Styled.ul>
                 <li>
                   Headings:{" "}
-                  <code class="language-text">
+                  <Styled.code className="language-text">
                     -apple-system, BlinkMacSystemFont, Helvetica, Arial,
                     sans-serif
-                  </code>
+                  </Styled.code>
                 </li>
                 <li>
                   Monospace:{" "}
-                  <code class="language-text">
+                  <Styled.code className="language-text">
                     SFMono-Regular, Consolas, Menlo, Andale, monospace
-                  </code>
+                  </Styled.code>
                 </li>
               </Styled.ul>
             </Styled.root>

--- a/src/pages/archive.js
+++ b/src/pages/archive.js
@@ -281,18 +281,6 @@ export default props => {
       fullWidth={true}
     >
       <YearsMatrix />
-
-      <div
-        sx={{
-          maxWidth: "container",
-          mx: "auto",
-          px: [4, 6, 7, 5],
-        }}
-      >
-        <p sx={{ fontSize: 0, fontFamily: "serif", color: "secondaty" }}>
-          *Not really everything
-        </p>
-      </div>
     </Layout>
   )
 }


### PR DESCRIPTION
- Makes code examples scroll horizontally instead of wrap. 

- Removes footnote from archive